### PR TITLE
Add better support for parsing vCard 2.1 files

### DIFF
--- a/src/vcf.js
+++ b/src/vcf.js
@@ -372,7 +372,7 @@ var VCF;
                 if((md = input.match(this.lineRE))) {
                     if(line && line.indexOf('QUOTED-PRINTABLE') != -1 && line.slice(-1) == '=') {
                         //Join multiline quoted-printables.  Newlines are escaped with a '='
-                        line = line.slice(0,-1) + '\r\n' + md[1];
+                        line = line.slice(0,-1) + md[1];
                         length = md[0].length;
                     } else {
                         if(line) {
@@ -410,6 +410,11 @@ var VCF;
         lexLine: function(line, callback) {
             var tmp = '';
             var key = null, attrs = {}, value = null, attrKey = null;
+
+            var qp = line.indexOf('ENCODING=QUOTED-PRINTABLE');
+            if(qp != -1){
+                line = line.substr(0,qp) + this.decodeQP(line.substr(qp+25));
+            }
 
             function finalizeKeyOrAttr() {
                 if(key) {
@@ -453,6 +458,21 @@ var VCF;
                     tmp += c;
                 }
             }
+        },
+        decodeQP: function(str){
+            str = (str || "").toString();
+            str = str.replace(/\=(?:\r?\n|$)/g, "");
+            var str2 = "";
+            for(var i=0, len = str.length; i<len; i++){
+                chr = str.charAt(i);
+                if(chr == "=" && (hex = str.substr(i+1, 2)) && /[\da-fA-F]{2}/.test(hex)){
+                    str2 += String.fromCharCode(parseInt(hex,16));
+                    i+=2;
+                    continue;
+                }
+                str2 += chr;
+            }
+            return str2;
         }
 
     };

--- a/src/vcf.js
+++ b/src/vcf.js
@@ -370,8 +370,9 @@ var VCF;
 
             for(;;) {
                 if((md = input.match(this.lineRE))) {
-                    // Join multiline quoted-printables (vCard 2.1) into a single line before parsing.
-                    // "Soft" linebreaks are indicated by a '=' at the end of the line.
+                    // Unfold quoted-printables (vCard 2.1) into a single line before parsing.
+                    // "Soft" linebreaks are indicated by a '=' at the end of the line, and do
+                    // not affect the underlying data.
                     if(line && line.indexOf('QUOTED-PRINTABLE') != -1 && line.slice(-1) == '=') {
                         line = line.slice(0,-1) + md[1];
                         length = md[0].length;

--- a/src/vcf.js
+++ b/src/vcf.js
@@ -370,8 +370,9 @@ var VCF;
 
             for(;;) {
                 if((md = input.match(this.lineRE))) {
+                    // Join multiline quoted-printables (vCard 2.1) into a single line before parsing.
+                    // "Soft" linebreaks are indicated by a '=' at the end of the line.
                     if(line && line.indexOf('QUOTED-PRINTABLE') != -1 && line.slice(-1) == '=') {
-                        //Join multiline quoted-printables.  Newlines are escaped with a '='
                         line = line.slice(0,-1) + md[1];
                         length = md[0].length;
                     } else {
@@ -411,6 +412,7 @@ var VCF;
             var tmp = '';
             var key = null, attrs = {}, value = null, attrKey = null;
 
+            //If our value is a quoted-printable (vCard 2.1), decode it and discard the encoding attribute
             var qp = line.indexOf('ENCODING=QUOTED-PRINTABLE');
             if(qp != -1){
                 line = line.substr(0,qp) + this.decodeQP(line.substr(qp+25));
@@ -459,6 +461,15 @@ var VCF;
                 }
             }
         },
+        /** Quoted Printable Parser
+          * 
+          * Parses quoted-printable strings, which sometimes appear in 
+          * vCard 2.1 files (usually the address field)
+          * 
+          * Code adapted from: 
+          * https://github.com/andris9/mimelib
+          *
+        **/
         decodeQP: function(str){
             str = (str || "").toString();
             str = str.replace(/\=(?:\r?\n|$)/g, "");

--- a/src/vcf.js
+++ b/src/vcf.js
@@ -143,6 +143,13 @@ var VCF;
                         value: attrs.VALUE
                     });
 
+                } else if(key =='ADR'){
+                    setAttr({
+                        type: attrs.TYPE,
+                        pref: attrs.PREF,
+                        value: value
+                    });
+                    //TODO: Handle 'LABEL' field.
                 } else {
                     console.log('WARNING: unhandled key: ', key);
                 }


### PR DESCRIPTION
Adds better support for parsing old vCard 2.1 files (#1).  Outlook and several other email clients still produce files in this format, so they're regrettably still fairly common in the wild.
- ADR fields are now supported.
  - LABELs still need to be implemented.
- QUOTED-PRINTABLE values are now correctly identified and decoded
- Supports vCard 2.1's boolean PREF attribute.
- Instead of discarding unknown attributes, assume that they belong to 'TYPE,' which they usually are in vC 2.1 files.
  - We could do this more intelligently by checking against the table in section 10.3.4 of the RFC.
